### PR TITLE
feat: add useButton

### DIFF
--- a/app/button/page.tsx
+++ b/app/button/page.tsx
@@ -1,0 +1,9 @@
+import { Button } from '@/components';
+
+export default function ButtonPage() {
+  return (
+    <div>
+      <Button />
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,8 @@
-import Image from 'next/image'
-import { Inter } from 'next/font/google'
-import styles from './page.module.css'
+import Image from 'next/image';
+import { Inter } from 'next/font/google';
+import styles from './page.module.css';
 
-const inter = Inter({ subsets: ['latin'] })
+const inter = Inter({ subsets: ['latin'] });
 
 export default function Home() {
   return (
@@ -87,5 +87,5 @@ export default function Home() {
         </a>
       </div>
     </main>
-  )
+  );
 }

--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -1,0 +1,12 @@
+'use client';
+import { useButton } from '@/hooks';
+
+export function Button() {
+  const buttonProps = useButton({
+    action: () => {
+      console.log('Fire the action');
+    },
+  });
+
+  return <div {...buttonProps}>Button...</div>;
+}

--- a/components/index.ts
+++ b/components/index.ts
@@ -1,0 +1,2 @@
+'use client';
+export * from './Button';

--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useButton';

--- a/hooks/useButton.ts
+++ b/hooks/useButton.ts
@@ -1,36 +1,38 @@
-import type { KeyboardEvent, KeyboardEventHandler, MouseEvent, MouseEventHandler } from 'react';
-
-export type ButtonState = {
-  disabled: boolean;
-};
+import type {
+  AriaAttributes,
+  AriaRole,
+  KeyboardEvent,
+  KeyboardEventHandler,
+  MouseEvent,
+  MouseEventHandler,
+} from 'react';
 
 export type ButtonProps<T = Element> = {
   /** The action may be fired by keyboard (space or enter) or the mouse click. */
   action: (event: KeyboardEvent<T> | MouseEvent<T>) => void;
+  /** Whether to set aria-disabled to true/ */
+  disabled?: boolean;
 };
 
-export function useButton<T = Element>({ action }: ButtonProps<T>) {
+type Return<T = Element> = {
+  role: AriaRole;
+  tabIndex: number;
+  onKeyUp: KeyboardEventHandler<T>;
+  onKeyDown: KeyboardEventHandler<T>;
+  onClick: MouseEventHandler<T>;
+  'aria-disabled': AriaAttributes['aria-disabled'];
+};
+
+export function useButton<T = Element>({ action, disabled }: ButtonProps<T>): Return<T> {
   const handleKeyUp: KeyboardEventHandler<T> = event => {
-    switch (event.key) {
-      case ' ':
-        action(event);
-
-        break;
-
-      default:
-        break;
+    if (event.key === ' ') {
+      action(event);
     }
   };
 
   const handleKeyDown: KeyboardEventHandler<T> = event => {
-    switch (event.key) {
-      case 'Enter':
-        action(event);
-
-        break;
-
-      default:
-        break;
+    if (event.key === 'Enter') {
+      action(event);
     }
   };
 
@@ -44,5 +46,6 @@ export function useButton<T = Element>({ action }: ButtonProps<T>) {
     onKeyUp: handleKeyUp,
     onKeyDown: handleKeyDown,
     onClick: handleClick,
+    'aria-disabled': disabled ? true : undefined,
   };
 }

--- a/hooks/useButton.ts
+++ b/hooks/useButton.ts
@@ -12,6 +12,8 @@ export type ButtonProps<T = Element> = {
   action: (event: KeyboardEvent<T> | MouseEvent<T>) => void;
   /** Whether to set aria-disabled to true/ */
   disabled?: boolean;
+  /** If the children of the button cannot be used as a recognized name, for example, an icon, then you should provide a label of the button. */
+  label?: string;
 };
 
 type Return<T = Element> = {
@@ -21,9 +23,10 @@ type Return<T = Element> = {
   onKeyDown: KeyboardEventHandler<T>;
   onClick: MouseEventHandler<T>;
   'aria-disabled': AriaAttributes['aria-disabled'];
+  'aria-label': AriaAttributes['aria-label'];
 };
 
-export function useButton<T = Element>({ action, disabled }: ButtonProps<T>): Return<T> {
+export function useButton<T = Element>({ action, disabled, label }: ButtonProps<T>): Return<T> {
   const handleKeyUp: KeyboardEventHandler<T> = event => {
     if (event.key === ' ') {
       action(event);
@@ -47,5 +50,6 @@ export function useButton<T = Element>({ action, disabled }: ButtonProps<T>): Re
     onKeyDown: handleKeyDown,
     onClick: handleClick,
     'aria-disabled': disabled ? true : undefined,
+    'aria-label': label,
   };
 }

--- a/hooks/useButton.ts
+++ b/hooks/useButton.ts
@@ -1,0 +1,48 @@
+import type { KeyboardEvent, KeyboardEventHandler, MouseEvent, MouseEventHandler } from 'react';
+
+export type ButtonState = {
+  disabled: boolean;
+};
+
+export type ButtonProps<T = Element> = {
+  /** The action may be fired by keyboard (space or enter) or the mouse click. */
+  action: (event: KeyboardEvent<T> | MouseEvent<T>) => void;
+};
+
+export function useButton<T = Element>({ action }: ButtonProps<T>) {
+  const handleKeyUp: KeyboardEventHandler<T> = event => {
+    switch (event.key) {
+      case ' ':
+        action(event);
+
+        break;
+
+      default:
+        break;
+    }
+  };
+
+  const handleKeyDown: KeyboardEventHandler<T> = event => {
+    switch (event.key) {
+      case 'Enter':
+        action(event);
+
+        break;
+
+      default:
+        break;
+    }
+  };
+
+  const handleClick: MouseEventHandler<T> = event => {
+    action(event);
+  };
+
+  return {
+    role: 'button',
+    tabIndex: 0,
+    onKeyUp: handleKeyUp,
+    onKeyDown: handleKeyDown,
+    onClick: handleClick,
+  };
+}

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './isUndefined';

--- a/utils/isUndefined.ts
+++ b/utils/isUndefined.ts
@@ -1,0 +1,3 @@
+export function isUndefined(value: any): value is undefined {
+  return typeof value === 'undefined';
+}


### PR DESCRIPTION
## What this pr complete

- `Space` to activate the button when keyup
- `Enter` to activate the button when keydown
- Activate the button when click
- The button has role of [button](https://w3c.github.io/aria/#button).
- The button has an accessible label. By default, the accessible name is computed from any text content inside the button element. However, it can also be provided with [aria-labelledby](https://w3c.github.io/aria/#aria-labelledby) or [aria-label](https://w3c.github.io/aria/#aria-label).
- When the action associated with a button is unavailable, the button has [aria-disabled](https://w3c.github.io/aria/#aria-disabled) set to true.

## What functionalities have not been implemented

- If activating the button opens a dialog, the focus moves inside the dialog. (see [dialog pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/))
- If activating the button closes a dialog, focus typically returns to the button that opened the dialog unless the function performed in the dialog context logically leads to a different element. For example, activating a cancel button in a dialog returns focus to the button that opened the dialog. However, if the dialog were confirming the action of deleting the page from which it was opened, the focus would logically move to a new context.
- If activating the button does not dismiss the current context, then focus typically remains on the button after activation, e.g., an Apply or Recalculate button.
- If the button action indicates a context change, such as move to next step in a wizard or add another search criteria, then it is often appropriate to move focus to the starting point for that action.
- If the button is activated with a shortcut key, the focus usually remains in the context from which the shortcut key was activated. For example, if Alt + U were assigned to an "Up" button that moves the currently focused item in a list one position higher in the list, pressing Alt + U when the focus is in the list would not move the focus from the list.
- If a description of the button's function is present, the button element has [aria-describedby](https://w3c.github.io/aria/#aria-describedby) set to the ID of the element containing the description.
- If the button is a toggle button, it has an [aria-pressed](https://w3c.github.io/aria/#aria-pressed) state. When the button is toggled on, the value of this state is true, and when toggled off, the state is false.

## Related issue

#6 