### PR TITLE
feat: add useToggleButton

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
   "typescript.tsdk": "node_modules/.pnpm/typescript@5.0.3/node_modules/typescript/lib",
-  "typescript.enablePromptUseWorkspaceTsdk": true
+  "typescript.enablePromptUseWorkspaceTsdk": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll": true
+  }
 }

--- a/app/button/page.tsx
+++ b/app/button/page.tsx
@@ -1,9 +1,10 @@
-import { Button } from '@/components';
+import { Button, ToggleButton } from '@/components';
 
 export default function ButtonPage() {
   return (
     <div>
       <Button />
+      <ToggleButton />
     </div>
   );
 }

--- a/components/ToggleButton.tsx
+++ b/components/ToggleButton.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { useToggleButton } from '@/hooks';
+
+export function ToggleButton() {
+  const { buttonProps } = useToggleButton({
+    action: () => {
+      console.log('Toggle');
+    },
+  });
+
+  return <div {...buttonProps}>Toggle button</div>;
+}

--- a/components/index.ts
+++ b/components/index.ts
@@ -1,2 +1,3 @@
 'use client';
 export * from './Button';
+export * from './ToggleButton';

--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from './useButton';
+export * from './useToggleButton';

--- a/hooks/useButton.ts
+++ b/hooks/useButton.ts
@@ -10,7 +10,7 @@ import type {
 export type ButtonProps<T = Element> = {
   /** The action may be fired by keyboard (space or enter) or the mouse click. */
   action: (event: KeyboardEvent<T> | MouseEvent<T>) => void;
-  /** Whether to set aria-disabled to true/ */
+  /** Whether the button is disabled. */
   disabled?: boolean;
   /** If the children of the button cannot be used as a recognized name, for example, an icon, then you should provide a label of the button. */
   label?: string;
@@ -18,7 +18,7 @@ export type ButtonProps<T = Element> = {
 
 type Return<T = Element> = {
   role: AriaRole;
-  tabIndex: number;
+  tabIndex?: number;
   onKeyUp: KeyboardEventHandler<T>;
   onKeyDown: KeyboardEventHandler<T>;
   onClick: MouseEventHandler<T>;
@@ -27,29 +27,34 @@ type Return<T = Element> = {
 };
 
 export function useButton<T = Element>({ action, disabled, label }: ButtonProps<T>): Return<T> {
+  const fireAction = (event: KeyboardEvent<T> | MouseEvent<T>) => {
+    if (disabled) return;
+    action(event);
+  };
+
   const handleKeyUp: KeyboardEventHandler<T> = event => {
     if (event.key === ' ') {
-      action(event);
+      fireAction(event);
     }
   };
 
   const handleKeyDown: KeyboardEventHandler<T> = event => {
     if (event.key === 'Enter') {
-      action(event);
+      fireAction(event);
     }
   };
 
   const handleClick: MouseEventHandler<T> = event => {
-    action(event);
+    fireAction(event);
   };
 
   return {
     role: 'button',
-    tabIndex: 0,
+    tabIndex: disabled ? undefined : 0,
     onKeyUp: handleKeyUp,
     onKeyDown: handleKeyDown,
     onClick: handleClick,
-    'aria-disabled': disabled ? true : undefined,
+    'aria-disabled': disabled,
     'aria-label': label,
   };
 }

--- a/hooks/useToggleButton.ts
+++ b/hooks/useToggleButton.ts
@@ -1,0 +1,27 @@
+import type { KeyboardEvent, MouseEvent } from 'react';
+import { useState } from 'react';
+import type { ButtonProps } from './useButton';
+import { useButton } from './useButton';
+
+export type ToggleButtonProps<T = Element> = {
+  defaultPressed?: boolean;
+} & ButtonProps<T>;
+
+export function useToggleButton<T = Element>({
+  defaultPressed = false,
+  action,
+  ...props
+}: ToggleButtonProps<T>) {
+  const [isPressed, setIsPressed] = useState(defaultPressed);
+  const handleAction = (event: MouseEvent<T> | KeyboardEvent<T>) => {
+    setIsPressed(!isPressed);
+    action(event);
+  };
+  const rawButtonProps = useButton({ action: handleAction, ...props });
+  const buttonProps = { ...rawButtonProps, 'aria-pressed': isPressed };
+
+  return {
+    isPressed,
+    buttonProps,
+  };
+}


### PR DESCRIPTION
## What this pr does

If the button is a toggle button, it has an [aria-pressed](https://w3c.github.io/aria/#aria-pressed) state. When the button is toggled on, the value of this state is true, and when toggled off, the state is false.

## Related issue

#6 